### PR TITLE
Escape underscores

### DIFF
--- a/debpack/usr/lib/nagios/plugins/notify-by-telegram.lua
+++ b/debpack/usr/lib/nagios/plugins/notify-by-telegram.lua
@@ -40,6 +40,7 @@ end
      Service = "*Service:*\n" .. arg[9] .. '\n\n'                  --$SERVICEDESC$
      message = emoji .. '\n\n' .. Alias .. Date_Time .. Notification .. Host  .. Service ..State .. Address .. Info
    end
+   message:gsub("_", "\\_")
 
 local data_str = 'parse_mode=Markdown&chat_id=' .. chat_id .. '&text=' .. message..''  
 local res, code, headers, status = https.request(telegram_url, data_str)


### PR DESCRIPTION
As per https://github.com/openhab/openhab-addons/pull/13758

Underscores in Telegram need to be escaped, otherwise the call to Telegram fails with:
"Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 178"

This commit escapes the underscores so the Telegram message will send.